### PR TITLE
feat: windows support

### DIFF
--- a/pdb_attach/__main__.py
+++ b/pdb_attach/__main__.py
@@ -2,9 +2,10 @@
 """Pdb-attach client that can be run as a module."""
 import argparse
 import os
-import signal
 import socket
 import sys
+
+from .pdb_detach import _signal
 
 PDB_PROMPT = "(Pdb) "
 
@@ -20,7 +21,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-os.kill(args.pid, signal.SIGUSR2)
+os.kill(args.pid, _signal)
 client = socket.create_connection(("localhost", args.port))
 try:
     client_io = client.makefile("rw", buffering=1)

--- a/pdb_attach/pdb_detach.py
+++ b/pdb_attach/pdb_detach.py
@@ -4,12 +4,15 @@ from __future__ import print_function
 
 import functools
 import logging
+import os
 import pdb
 import signal
 import socket
 
+# Windows does not have SIGUSR[12], so use SIGBREAK instead.
+_signal = signal.SIGUSR2 if os.name == 'posix' else signal.SIGBREAK
 
-_original_handler = signal.getsignal(signal.SIGUSR2)
+_original_handler = signal.getsignal(_signal)
 
 
 class PdbDetach(pdb.Pdb):
@@ -89,11 +92,11 @@ def listen(port):
     if isinstance(port, str):
         port = int(port)
     handler = functools.partial(_handler, port)
-    signal.signal(signal.SIGUSR2, handler)
+    signal.signal(_signal, handler)
 
 
 def unlisten():
     """Stop listening."""
-    cur_sig = signal.getsignal(signal.SIGUSR2)
+    cur_sig = signal.getsignal(_signal)
     if hasattr(cur_sig, "func") and cur_sig.func is _handler:
-        signal.signal(signal.SIGUSR2, _original_handler)
+        signal.signal(_signal, _original_handler)

--- a/pdb_attach/pdb_detach.py
+++ b/pdb_attach/pdb_detach.py
@@ -10,7 +10,7 @@ import signal
 import socket
 
 # Windows does not have SIGUSR[12], so use SIGBREAK instead.
-_signal = signal.SIGUSR2 if os.name == 'posix' else signal.SIGBREAK
+_signal = signal.SIGUSR2 if os.name == 'posix' else signal.SIGINT
 
 _original_handler = signal.getsignal(_signal)
 

--- a/pdb_attach/pdb_detach.pyi
+++ b/pdb_attach/pdb_detach.pyi
@@ -1,8 +1,9 @@
 import pdb
+import signal
 from types import FrameType
 from typing import Any, Callable, List, Union
 
-__version__: str
+_signal: signal.Signals
 _original_handler: Any
 PDB_PROMPT: str
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,4 +54,4 @@ testing =
 
 [flake8]
 per-file-ignores =
-    test/test_pdb_attach.py:E402,S101,S404,S603,S607
+    test/test_pdb_attach.py:E402,S101,S404,S602,S603,S607

--- a/test/test_pdb_attach.py
+++ b/test/test_pdb_attach.py
@@ -55,9 +55,9 @@ def test_correct_detach_line():
 def test_signal_set():
     """Test the signal handler is set and unset by listen and unlisten."""
     pdb_attach.listen(0)
-    assert signal.getsignal(signal.SIGUSR2).func is pdb_detach._handler
+    assert signal.getsignal(pdb_detach._signal).func is pdb_detach._handler
     pdb_attach.unlisten()
-    cur_sig = signal.getsignal(signal.SIGUSR2)
+    cur_sig = signal.getsignal(pdb_detach._signal)
     if hasattr(cur_sig, "func"):
         assert cur_sig.func is not pdb_detach._handler
     else:

--- a/test/test_pdb_attach.py
+++ b/test/test_pdb_attach.py
@@ -87,5 +87,6 @@ def test_precmd_handler_runs():
 def test_end_to_end(free_port):
     """End to end test(s)."""
     test_script = os.path.abspath(os.path.join(os.path.dirname(__file__), 'end_to_end.sh'))
-    returncode = subprocess.call(['bash', test_script, str(free_port)])
+    # GitHub Actions for Windows runners fails to find bash on PATH without `shell=True`.
+    returncode = subprocess.call('bash {} {}'.format(test_script, free_port), shell=True)
     assert returncode == 0


### PR DESCRIPTION
On Windows use signal SIGBREAK instead of SIGUSR2, which doesn't exist
on Windows, to signal PdbDetach to start running.