### PR TITLE
fix: raise a warning on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,23 +40,18 @@ jobs:
       matrix:
         python: ['2.7', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9']
         os: [ubuntu-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            python: ['3.3', '3.4']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    - name: Upgrade pip
-      if: ${{ matrix.python != '3.3' }}
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-    - name: Install dependencies
-      if: ${{ matrix.python == '3.3' }}
-      run: |
-        pip install pytest
-    - name: Install dependencies
-      if: ${{ matrix.python != '3.3' }}
-      run: |
         python -m pip install pytest
     - name: Type check with Mypy
       if: ${{ matrix.python != '2.7' && matrix.python != '3.3' && matrix.python != '3.4' && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
+    - name: Upgrade pip
+      if: ${{ matrix.python != '3.3' }}
+      run: |
+        python -m pip install --upgrade pip
     - name: Install dependencies
       run: |
-        if [ ${{ matrix.os }} == "windows-latest" && ${{ matrix.python }} != "3.3" ]; then
-            python -m pip install --upgrade pip
-        fi
         python -m pip install pytest
     - name: Type check with Mypy
       if: ${{ matrix.python != '2.7' && matrix.python != '3.3' && matrix.python != '3.4' && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
     - name: Install dependencies
+      if: ${{ matrix.python == '3.3' }}
+      run: |
+        pip install pytest
+    - name: Install dependencies
+      if: ${{ matrix.python != '3.3' }}
       run: |
         python -m pip install pytest
     - name: Type check with Mypy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest
-            python: ['3.3', '3.4']
+            python: '3.3'
+          - os: windows-latest
+            python: '3.4'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        if [ ${{ matrix.os }} == "windows-latest" && ${{ matrix.python }} != "3.3" ]; then
+            python -m pip install --upgrade pip
+        fi
         python -m pip install pytest
     - name: Type check with Mypy
       if: ${{ matrix.python != '2.7' && matrix.python != '3.3' && matrix.python != '3.4' && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         python: ['2.7', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9']
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}
@@ -51,7 +51,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pytest
     - name: Type check with Mypy
-      if: ${{ matrix.python != '2.7' && matrix.python != '3.3' && matrix.python != '3.4' }}
+      if: ${{ matrix.python != '2.7' && matrix.python != '3.3' && matrix.python != '3.4' && matrix.os == 'ubuntu-latest' }}
       run: |
         python -m pip install mypy
         mypy --no-incremental -p pdb_attach

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Supports OSes that implement POSIX only.
 
 Unfortunately pdb-attach doesn't work on Windows. It's an artifact of the implementation using signals to prompt the remote debugger to accept a socket connection. I would like to support Windows in the future, but because of how Windows handles signals, it will require a different implementation that doesn't rely on signals.
 
+> :warning: On Windows, pdb-attach is still importable, but `listen` won't do anything. Instead a warning will be raised on import and when `listen` is called.
+
 ### Python versions ###
 
 Currently supports:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,29 @@ This package was made in response to frustration over debugging long running pro
 $ pip install pdb-attach
 ```
 
+## Requirements ##
+
+### OS ###
+
+Supports OSes that implement POSIX only.
+
+Unfortunately pdb-attach doesn't work on Windows. It's an artifact of the implementation using signals to prompt the remote debugger to accept a socket connection. I would like to support Windows in the future, but because of how Windows handles signals, it will require a different implementation that doesn't rely on signals.
+
+### Python versions ###
+
+Currently supports:
+
+- 2.7
+- 3.3
+- 3.4
+- 3.5
+- 3.6
+- 3.7
+- 3.8
+- 3.9
+
+The policy on python version support is to support all active versions of python. For any version that has reached end of life, that version will continue to be supported for the last major release of pdb-attach it was a part of. New major releases of pdb-attach after a python version has been end of lifed may drop support for that version of python.
+
 ## Usage ##
 
 > :warning: pdb-attach uses sockets to communicate with the running process where `pdb` is actually being executed. While the window to connect to that process is very small, there is always the possibility that a bad actor that has access to your machine can connect to that port before you do. Since `pdb` is an interactive session with the process, this would give them the ability to inspect the source code of the running process, modify state of the running process, and **_run python code as you!_** That is bad and now you've been warned.

--- a/pdb_attach/__init__.py
+++ b/pdb_attach/__init__.py
@@ -1,6 +1,8 @@
 # -*- mode: python -*-
 """pdb-attach is a python debugger that can attach to running processes."""
 import os
+import platform
+import warnings
 
 from .pdb_detach import listen, unlisten
 
@@ -8,3 +10,12 @@ __all__ = ["listen", "unlisten"]
 
 with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "VERSION.txt")) as f:
     __version__ = f.read().strip()
+
+if platform.system() == "Windows":
+    warnings.warn(
+        (
+            "pdb-attach does not support Windows. listen() does nothing and the "
+            "pdb-attach client will not be able to attach to this process."
+        ),
+        UserWarning,
+    )

--- a/pdb_attach/pdb_detach.pyi
+++ b/pdb_attach/pdb_detach.pyi
@@ -1,8 +1,12 @@
 import pdb
 from types import FrameType
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, List, TypeVar, Union
 
 _original_handler: Any
+
+F = TypeVar('F', bound=Callable[..., Any])
+
+def _skip_windows(f: F) -> F: ...
 
 class PdbDetach(pdb.Pdb):
     use_rawinput: bool = ...

--- a/pdb_attach/pdb_detach.pyi
+++ b/pdb_attach/pdb_detach.pyi
@@ -2,8 +2,6 @@ import pdb
 from types import FrameType
 from typing import Any, Callable, List, TypeVar, Union
 
-_original_handler: Any
-
 F = TypeVar('F', bound=Callable[..., Any])
 
 def _skip_windows(f: F) -> F: ...

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,7 @@
+# -*- mode: python -*-
+"""pytest specific code."""
+import platform
+
+
+if platform.system() != "Windows":
+    collect_ignore = ["test_windows_import.py"]

--- a/test/context.py
+++ b/test/context.py
@@ -4,9 +4,11 @@ For tests, import ``pdb_attach`` and other related modules from this module inst
 directly. This ensures ``pdb_attach`` is on the path.
 """
 import os
+import platform
 import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
+import pytest
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
 import pdb_attach
 import pdb_attach.pdb_detach as pdb_detach

--- a/test/skip.py
+++ b/test/skip.py
@@ -1,0 +1,13 @@
+# -*- mode: python -*-
+"""General pytest decorators for skipping tests."""
+import platform
+
+import pytest
+
+
+is_windows = False
+if platform.system() == "Windows":
+    is_windows = True
+
+
+skip_windows = pytest.mark.skipif(is_windows, reason="Lacks Windows support.")

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -11,6 +11,7 @@ except ImportError:
     from test.support import find_unused_port
 
 from context import pdb_attach
+from skip import skip_windows
 
 
 def infinite_loop(port, channel):
@@ -27,6 +28,7 @@ def infinite_loop(port, channel):
     pdb_attach.unlisten()
 
 
+@skip_windows
 def test_end_to_end():
     """Test client commands are honored.
 

--- a/test/test_pdb_attach.py
+++ b/test/test_pdb_attach.py
@@ -46,6 +46,15 @@ def test_signal_set():
     assert not isinstance(signal.getsignal(signal.SIGUSR2), pdb_detach._Handler)
 
 
+@skip_windows
+def test_original_signal_restored():
+    """Test the original signal is restored by unlisten."""
+    pdb_attach.listen(0)
+    cur_sig = signal.getsignal(signal.SIGUSR2)
+    pdb_attach.unlisten()
+    assert cur_sig.original_handler is signal.getsignal(signal.SIGUSR2)
+
+
 def test_precmd_handler_runs():
     """Test attached precmd handler is executed.
 

--- a/test/test_pdb_attach.py
+++ b/test/test_pdb_attach.py
@@ -7,6 +7,7 @@ import os
 import signal
 
 from context import pdb_attach, pdb_detach
+from skip import skip_windows
 
 
 def test_detach():
@@ -36,6 +37,7 @@ def test_correct_detach_line():
     assert val is True
 
 
+@skip_windows
 def test_signal_set():
     """Test the signal handler is set and unset by listen and unlisten."""
     pdb_attach.listen(0)

--- a/test/test_windows_import.py
+++ b/test/test_windows_import.py
@@ -1,16 +1,28 @@
 # -*- mode: python -*-
 """Test import warning on Windows."""
+import os
+import sys
 import warnings
 
 import pytest
 
 warnings.simplefilter("always")
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
+
 
 def test_import_raises_warning():
     """Test importing pdb_attach raises a warning."""
-    with pytest.warns(UserWarning):
+
+    def import_pdb_attach():
+        """Pytest doesn't catch warnings emitted by imports well.
+
+        It can catch them from function calls though.
+        """
         import pdb_attach  # noqa: F401
+
+    with pytest.warns(UserWarning):
+        import_pdb_attach()
 
 
 def test_listen_raises_warning():

--- a/test/test_windows_import.py
+++ b/test/test_windows_import.py
@@ -1,7 +1,10 @@
 # -*- mode: python -*-
 """Test import warning on Windows."""
+import warnings
+
 import pytest
 
+warnings.simplefilter("always")
 
 def test_import_raises_warning():
     """Test importing pdb_attach raises a warning."""

--- a/test/test_windows_import.py
+++ b/test/test_windows_import.py
@@ -6,6 +6,7 @@ import pytest
 
 warnings.simplefilter("always")
 
+
 def test_import_raises_warning():
     """Test importing pdb_attach raises a warning."""
     with pytest.warns(UserWarning):

--- a/test/test_windows_import.py
+++ b/test/test_windows_import.py
@@ -1,0 +1,20 @@
+# -*- mode: python -*-
+"""Test import warning on Windows."""
+import pytest
+
+
+def test_import_raises_warning():
+    """Test importing pdb_attach raises a warning."""
+    with pytest.warns(UserWarning):
+        import pdb_attach  # noqa: F401
+
+
+def test_listen_raises_warning():
+    """Test calling listen and unlisten raise a warning."""
+    import pdb_attach
+
+    with pytest.warns(UserWarning):
+        pdb_attach.listen(50000)
+
+    with pytest.warns(UserWarning):
+        pdb_attach.unlisten()

--- a/test/test_windows_import.py
+++ b/test/test_windows_import.py
@@ -13,8 +13,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pa
 
 def test_listen_raises_warning():
     """Test warnings are raised."""
-    with pytest.warns(UserWarning):
-        import pdb_attach
+    import pdb_attach
 
     with pytest.warns(UserWarning):
         pdb_attach.listen(50000)

--- a/test/test_windows_import.py
+++ b/test/test_windows_import.py
@@ -11,23 +11,10 @@ warnings.simplefilter("always")
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
 
 
-def test_import_raises_warning():
-    """Test importing pdb_attach raises a warning."""
-
-    def import_pdb_attach():
-        """Pytest doesn't catch warnings emitted by imports well.
-
-        It can catch them from function calls though.
-        """
-        import pdb_attach  # noqa: F401
-
-    with pytest.warns(UserWarning):
-        import_pdb_attach()
-
-
 def test_listen_raises_warning():
-    """Test calling listen and unlisten raise a warning."""
-    import pdb_attach
+    """Test warnings are raised."""
+    with pytest.warns(UserWarning):
+        import pdb_attach
 
     with pytest.warns(UserWarning):
         pdb_attach.listen(50000)


### PR DESCRIPTION
Windows is not supported. Instead of an exception being raised by
accessing SIGUSR2 which doesn't exist on Windows, do nothing and raise
a warning. This way, pdb-attach doesn't impact user code and users
don't have to do try-except imports.

Related #4