### PR TITLE
Defensive coding suggestion

### DIFF
--- a/pdb_attach/__main__.py
+++ b/pdb_attach/__main__.py
@@ -48,6 +48,9 @@ while True:
         # Ignore flake8 warning about input in Python 2.7 since we are checking for raw_input first.
         to_server = input("".join(lines))  # noqa: S322
 
+    if not to_server:
+        continue
+    
     if to_server[-1] != "\n":
         to_server += "\n"
 

--- a/pdb_attach/__main__.py
+++ b/pdb_attach/__main__.py
@@ -48,10 +48,8 @@ while True:
         # Ignore flake8 warning about input in Python 2.7 since we are checking for raw_input first.
         to_server = input("".join(lines))  # noqa: S322
 
-    if not to_server:
-        continue
-    
-    if to_server[-1] != "\n":
+    if len(to_server) == 0 or to_server[-1] != "\n":
         to_server += "\n"
 
     client_io.write(to_server)
+    client_io.flush()

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -10,8 +10,6 @@ try:
 except ImportError:
     from test.support import find_unused_port
 
-import pytest
-
 from context import pdb_attach
 from skip import skip_windows
 
@@ -25,7 +23,7 @@ def infinite_loop():
 
 
 def run_function(func, commands):
-    """Runs the function in a separate process with `pdb-attach` and sends it commands.
+    """Run the function in a separate process with `pdb-attach` and send it commands.
 
     Args
     ----


### PR DESCRIPTION
I didn't study if this is really necessary in general, but in my use case pdb_attach raises an exception and exited when the application being debugged logged an info message. The issue was "to_server" was empty.  Perhaps this points to a deeper issue, but this change was sufficient to make my use case work.

Thanks for contributing this!  I don't understand why this is not a build in capability.