### PR TITLE
Poll socket serverside

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python: ['2.7', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['2.7', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'latest']
         os: ['ubuntu-18.04', windows-latest]
         exclude:
           - os: windows-latest

--- a/pdb_attach/__init__.py
+++ b/pdb_attach/__init__.py
@@ -5,6 +5,7 @@ import platform
 import warnings
 
 from pdb_attach.pdb_signal import PdbSignal
+from pdb_attach.pdb_select import PdbSelect
 
 __all__ = ["listen", "unlisten"]
 
@@ -12,20 +13,21 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "VERSION.txt"
     __version__ = f.read().strip()
 
 if platform.system() == "Windows":
-    warnings.warn(
-        (
-            "pdb-attach does not support Windows. listen() does nothing and the "
-            "pdb-attach client will not be able to attach to this process."
-        ),
-        UserWarning,
-    )
+    def listen(port):
+        """Start listening on port."""
+        PdbSelect.listen(port)
 
 
-def listen(port):
-    """Start listening on port."""
-    PdbSignal.listen(port)
+    def unlisten():
+        """Stop listening."""
+        PdbSelect.unlisten()
+
+else:
+    def listen(port):
+        """Start listening on port."""
+        PdbSignal.listen(port)
 
 
-def unlisten():
-    """Stop listening."""
-    PdbSignal.unlisten()
+    def unlisten():
+        """Stop listening."""
+        PdbSignal.unlisten()

--- a/pdb_attach/pdb_select.py
+++ b/pdb_attach/pdb_select.py
@@ -1,0 +1,53 @@
+# -*- mode: python -*-
+"""Pdb server using polling."""
+import select
+import sys
+
+from pdb_attach.detach import PdbDetach
+from pdb_attach.pdb_socket import PdbServer
+
+
+class PdbSelect(PdbServer, PdbDetach):
+    """Pdb polling server."""
+    def __init__(self, port, *args, **kwargs):
+        PdbDetach.__init__(self, *args, **kwargs)
+        PdbServer.__init__(self, port, *args, **kwargs)
+        self._poller = select.poll()
+        self._poller.register(self._sock, select.POLLIN)
+        self._counter = 0
+        sys.settrace(self._trace)
+
+    def __del__(self):
+        self.close()
+
+    @classmethod
+    def listen(cls, port, *args, **kwargs):
+        """Set up the trace."""
+        cls(port, *args, **kwargs)
+
+    @classmethod
+    def unlisten(cls):
+        """Remove the trace."""
+        sys.settrace(None)
+
+    def _trace(self, frame, event, arg):
+        """Poll the socket and start the debugger if a connection is waiting."""
+        if self._counter < 100:
+            self._counter += 1
+            return self._trace
+
+        self._counter = 0
+        fps = self._poller.poll(0)
+        if len(fps) > 1:
+            raise ValueError("Unexpected number of file descriptors.")
+
+        elif len(fps) == 0:
+            return self._trace
+
+        self.set_trace(frame)
+
+    def do_detach(self, arg):
+        """Detach the debugger and reset the trace."""
+        rv = PdbDetach.do_detach(self, arg)
+        sys.settrace(self._trace)
+        return rv

--- a/test/context.py
+++ b/test/context.py
@@ -14,3 +14,4 @@ import pdb_attach
 import pdb_attach.detach as pdb_detach
 import pdb_attach.pdb_socket as pdb_socket
 import pdb_attach.pdb_signal as pdb_signal
+import pdb_attach.pdb_select as pdb_select

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -11,8 +11,6 @@ try:
 except ImportError:
     from test.support import find_unused_port
 
-from skip import skip_windows
-
 
 pdb_path = os.path.abspath(
     os.path.join(os.path.abspath(os.path.dirname(__file__)), os.pardir)
@@ -89,7 +87,6 @@ expected_detach = os.linesep.join(
 ).replace("/path/to/pdb-attach", pdb_path)
 
 
-@skip_windows
 def test_end_to_end_detach():
     """Test the `detach` command."""
     actual_lines, done = run_script("detach")
@@ -109,7 +106,6 @@ expected_empty = os.linesep.join(
 ).replace("/path/to/pdb-attach", pdb_path)
 
 
-@skip_windows
 def test_end_to_end_empty():
     """Test an empty line."""
     actual_lines, done = run_script("empty")

--- a/test/test_signal.py
+++ b/test/test_signal.py
@@ -1,5 +1,5 @@
 # -*- mode: python -*-
-"""PdbDetach tests."""
+"""PdbSignal tests."""
 from __future__ import unicode_literals
 
 import signal

--- a/test/test_socket.py
+++ b/test/test_socket.py
@@ -1,5 +1,5 @@
 # -*- mode: python -*-
-"""PdbServer tests."""
+"""Pdb client/server tests."""
 from __future__ import unicode_literals
 
 import io

--- a/test/test_windows_import.py
+++ b/test/test_windows_import.py
@@ -1,6 +1,7 @@
 # -*- mode: python -*-
 """Test import warning on Windows."""
 import os
+import platform
 import sys
 import warnings
 
@@ -11,6 +12,7 @@ warnings.simplefilter("always")
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
 
 
+@pytest.mark.xfail(platform.system() == "Windows", reason="Double check warnings aren't raised for Windows")
 def test_listen_raises_warning():
     """Test warnings are raised."""
     import pdb_attach


### PR DESCRIPTION
A new class that polls the server side socket periodically.

This change allows for Windows users to use pdb-attach since the initial method for starting a connection between client and server is through signals. Signals just kill processes on Windows.

Fix #4 